### PR TITLE
test/lookups: fix end time for stella + xmile models

### DIFF
--- a/tests/lookups/test_lookups.stmx
+++ b/tests/lookups/test_lookups.stmx
@@ -13,7 +13,7 @@
     </style>
     <sim_specs method="Euler" time_units="Time">
         <start>0</start>
-        <stop>12</stop>
+        <stop>45</stop>
         <dt>0.25</dt>
     </sim_specs>
     <model_units />

--- a/tests/lookups/test_lookups_no-indirect.stmx
+++ b/tests/lookups/test_lookups_no-indirect.stmx
@@ -13,7 +13,7 @@
     </style>
     <sim_specs method="Euler" time_units="Time">
         <start>0</start>
-        <stop>12</stop>
+        <stop>45</stop>
         <dt>0.25</dt>
     </sim_specs>
     <model_units />

--- a/tests/lookups/test_lookups_no-indirect.xmile
+++ b/tests/lookups/test_lookups_no-indirect.xmile
@@ -9,7 +9,7 @@
     </header>
     <sim_specs time_units="Time">
         <start>0</start>
-        <stop>12</stop>
+        <stop>45</stop>
         <dt>0.25</dt>
     </sim_specs>
     <dimensions></dimensions>


### PR DESCRIPTION
I generated the output file with the correct end-time, but apparently
didn't think to save the models after that.