### PR TITLE
add compare + regression-test scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,3 +86,45 @@ expected by tools that interact with this repository.
 6. Under `Export As` choose `CSV`
 7. Under `Time Running` choose `down`
 8. Click `OK at the bottom left to perform the export
+
+## Tool testing
+
+There are 2 scripts in the top level of this repo to aid in debugging,
+[compare.py](compare.py) and [regression-test.py](regression-test.py).
+`compare.py` expects paths to two CSV or TSV files, and will compare the
+results of the two files, with some amount of smartness/fuzziness
+around floating point comparisions.
+
+`regression-test.py` can be used to compare a specific modeling tool's
+output against the accepted, canonical output for a given model (which
+is stored in `output.csv` in all the subdirectories of this
+repository).  It can be run with external tools with the current
+working directory as the root of this project:
+
+    $ ./regression-test.py ~/src/libsd/mdl .
+    $ ./regression-test.py ~/src/sd.js/mdl.js .
+
+And it can also be run from outside of this project, for example when
+this `test-models` repo is included as a [git
+submodule](https://git-scm.com/book/en/v2/Git-Tools-Submodules) in
+another project:
+
+    $ test/test-models/regression-test.py ./mdl test/test-models
+
+The main requirement is that the given command
+([`mdl`](https://github.com/sdlabs/libsd/blob/master/mdl.c) and
+[`mdl.js`](https://github.com/sdlabs/sd.js/blob/master/mdl.js) above)
+accept the path to a model as an argument, and output model results to
+`stdout` in either TSV or CSV format.  If your tool requires
+additional commandline args, you can specify them with quoting:
+
+    $ ./regression-test.py "~/path/to/tool --arg1 --arg2" .
+
+And if you have a tool that simulates Vensim models or Stella v10
+models rather than xmile, you can change the model-file suffix:
+
+    # test Vensim model files
+    $ ./regression-test.py --ext mdl ~/path/to/tool .
+
+    # test Stella v10 XMILE-variant model files
+    $ ./regression-test.py --ext stmx ~/path/to/tool .

--- a/compare.py
+++ b/compare.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python
+
+import cmath
+import csv
+import os
+import os.path
+import math
+import re
+import subprocess
+import sys
+
+# these columns are either Vendor specific or otherwise not important.
+IGNORABLE_COLS = ('saveper',)
+
+# from rainbow
+def make_reporter(verbosity, quiet, filelike):
+    if not quiet:
+        def report(level, msg, *args):
+            if level <= verbosity:
+                if len(args):
+                    filelike.write(msg % args + '\n')
+                else:
+                    filelike.write('%s\n' % (msg,))
+    else:
+        def report(level, msg, *args): pass
+    return report
+
+ERROR = 0
+WARN = 1
+INFO = 2
+DEBUG = 3
+log = make_reporter(DEBUG, False, sys.stderr)
+
+def isclose(a,
+            b,
+            rel_tol=1e-9,
+            abs_tol=0.0,
+            method='weak'):
+    """
+    returns True if a is close in value to b. False otherwise
+    :param a: one of the values to be tested
+    :param b: the other value to be tested
+    :param rel_tol=1e-8: The relative tolerance -- the amount of error
+                         allowed, relative to the magnitude of the input
+                         values.
+    :param abs_tol=0.0: The minimum absolute tolerance level -- useful for
+                        comparisons to zero.
+    :param method: The method to use. options are:
+                  "asymmetric" : the b value is used for scaling the tolerance
+                  "strong" : The tolerance is scaled by the smaller of
+                             the two values
+                  "weak" : The tolerance is scaled by the larger of
+                           the two values
+                  "average" : The tolerance is scaled by the average of
+                              the two values.
+    NOTES:
+    -inf, inf and NaN behave similar to the IEEE 754 standard. That
+    -is, NaN is not close to anything, even itself. inf and -inf are
+    -only close to themselves.
+    Complex values are compared based on their absolute value.
+    The function can be used with Decimal types, if the tolerance(s) are
+    specified as Decimals::
+      isclose(a, b, rel_tol=Decimal('1e-9'))
+    See PEP-0485 for a detailed description
+
+    Copyright: Christopher H. Barker
+    License: Apache License 2.0 http://opensource.org/licenses/apache2.0.php
+    """
+    if method not in ("asymmetric", "strong", "weak", "average"):
+        raise ValueError('method must be one of: "asymmetric",'
+                         ' "strong", "weak", "average"')
+
+    if rel_tol < 0.0 or abs_tol < 0.0:
+        raise ValueError('error tolerances must be non-negative')
+
+    if a == b:  # short-circuit exact equality
+        return True
+    # use cmath so it will work with complex or float
+    if cmath.isinf(a) or cmath.isinf(b):
+        # This includes the case of two infinities of opposite sign, or
+        # one infinity and one finite number. Two infinities of opposite sign
+        # would otherwise have an infinite relative tolerance.
+        return False
+    diff = abs(b - a)
+    if method == "asymmetric":
+        return (diff <= abs(rel_tol * b)) or (diff <= abs_tol)
+    elif method == "strong":
+        return (((diff <= abs(rel_tol * b)) and
+                 (diff <= abs(rel_tol * a))) or
+                (diff <= abs_tol))
+    elif method == "weak":
+        return (((diff <= abs(rel_tol * b)) or
+                 (diff <= abs(rel_tol * a))) or
+                (diff <= abs_tol))
+    elif method == "average":
+        return ((diff <= abs(rel_tol * (a + b) / 2) or
+                (diff <= abs_tol)))
+    else:
+        raise ValueError('method must be one of:'
+                         ' "asymmetric", "strong", "weak", "average"')
+
+def slurp(file_name):
+    with open(file_name, 'r') as f:
+        return f.read().strip()
+
+def load_csv(f, delimiter=','):
+    result = []
+    reader = csv.reader(f, delimiter=delimiter)
+    header = next(reader)
+    for i in range(len(header)):
+        result.append([header[i]])
+    for row in reader:
+        for i in range(len(row)):
+            result[i].append(row[i])
+    series = {}
+    for i in range(len(result)):
+        series[result[i][0]] = result[i][1:]
+    return series
+
+NAME_RE = re.compile(' +')
+
+def e_name(n):
+    return NAME_RE.sub('_', n)
+
+def read_data(data):
+    ins = data.lower().splitlines()
+    ins[0] = e_name(ins[0].strip())
+    if ',' in ins[0]:
+        delimiter = ','
+    else:
+        delimiter = '\t'
+    return load_csv(ins, delimiter)
+
+def compare(reference, simulated):
+    time = reference['time']
+    steps = len(time)
+    err = False
+    for i in range(steps):
+        for n, series in list(reference.items()):
+            if n not in simulated:
+                if n in IGNORABLE_COLS:
+                    continue
+                log(ERROR, 'missing column %s in second file', n)
+                break
+            if len(reference[n]) != len(simulated[n]):
+                log(ERROR, 'len mismatch for %s (%d vs %d)',
+                    n, len(reference[n]), len(simulated[n]))
+                err = True
+                break
+            ref = float(series[i])
+            sim = float(simulated[n][i])
+            around_zero = isclose(ref, 0, abs_tol=1e-06) and isclose(sim, 0, abs_tol=1e-06)
+            if not around_zero and not isclose(ref, sim, rel_tol=1e-4):
+                log(ERROR, 'time %s mismatch in %s (%s != %s)', time[i], n, ref, sim)
+                err = True
+
+def main():
+    ref = read_data(slurp(sys.argv[1]))
+    sim = read_data(slurp(sys.argv[2]))
+    compare(ref, sim)
+    return
+
+if __name__ == '__main__':
+    exit(main())

--- a/regression-test.py
+++ b/regression-test.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python
+
+import argparse
+import cmath
+import csv
+import os
+import os.path
+import math
+import re
+import subprocess
+import sys
+
+OUTPUT_FILE = 'output.csv'
+
+# these columns are either Vendor specific or otherwise not important.
+IGNORABLE_COLS = ('saveper',)
+
+# from rainbow
+def make_reporter(verbosity, quiet, filelike):
+    if not quiet:
+        def report(level, msg, *args):
+            if level <= verbosity:
+                if len(args):
+                    filelike.write(msg % args + '\n')
+                else:
+                    filelike.write('%s\n' % (msg,))
+    else:
+        def report(level, msg, *args): pass
+    return report
+
+ERROR = 0
+WARN = 1
+INFO = 2
+DEBUG = 3
+log = make_reporter(DEBUG, False, sys.stderr)
+
+def isclose(a,
+            b,
+            rel_tol=1e-9,
+            abs_tol=0.0,
+            method='weak'):
+    """
+    returns True if a is close in value to b. False otherwise
+    :param a: one of the values to be tested
+    :param b: the other value to be tested
+    :param rel_tol=1e-8: The relative tolerance -- the amount of error
+                         allowed, relative to the magnitude of the input
+                         values.
+    :param abs_tol=0.0: The minimum absolute tolerance level -- useful for
+                        comparisons to zero.
+    :param method: The method to use. options are:
+                  "asymmetric" : the b value is used for scaling the tolerance
+                  "strong" : The tolerance is scaled by the smaller of
+                             the two values
+                  "weak" : The tolerance is scaled by the larger of
+                           the two values
+                  "average" : The tolerance is scaled by the average of
+                              the two values.
+    NOTES:
+    -inf, inf and NaN behave similar to the IEEE 754 standard. That
+    -is, NaN is not close to anything, even itself. inf and -inf are
+    -only close to themselves.
+    Complex values are compared based on their absolute value.
+    The function can be used with Decimal types, if the tolerance(s) are
+    specified as Decimals::
+      isclose(a, b, rel_tol=Decimal('1e-9'))
+    See PEP-0485 for a detailed description
+
+    Copyright: Christopher H. Barker
+    License: Apache License 2.0 http://opensource.org/licenses/apache2.0.php
+    """
+    if method not in ("asymmetric", "strong", "weak", "average"):
+        raise ValueError('method must be one of: "asymmetric",'
+                         ' "strong", "weak", "average"')
+
+    if rel_tol < 0.0 or abs_tol < 0.0:
+        raise ValueError('error tolerances must be non-negative')
+
+    if a == b:  # short-circuit exact equality
+        return True
+    # use cmath so it will work with complex or float
+    if cmath.isinf(a) or cmath.isinf(b):
+        # This includes the case of two infinities of opposite sign, or
+        # one infinity and one finite number. Two infinities of opposite sign
+        # would otherwise have an infinite relative tolerance.
+        return False
+    diff = abs(b - a)
+    if method == "asymmetric":
+        return (diff <= abs(rel_tol * b)) or (diff <= abs_tol)
+    elif method == "strong":
+        return (((diff <= abs(rel_tol * b)) and
+                 (diff <= abs(rel_tol * a))) or
+                (diff <= abs_tol))
+    elif method == "weak":
+        return (((diff <= abs(rel_tol * b)) or
+                 (diff <= abs(rel_tol * a))) or
+                (diff <= abs_tol))
+    elif method == "average":
+        return ((diff <= abs(rel_tol * (a + b) / 2) or
+                (diff <= abs_tol)))
+    else:
+        raise ValueError('method must be one of:'
+                         ' "asymmetric", "strong", "weak", "average"')
+
+def slurp(file_name):
+    with open(file_name, 'r') as f:
+        return f.read().strip()
+
+def load_csv(f, delimiter=','):
+    result = []
+    reader = csv.reader(f, delimiter=delimiter)
+    header = next(reader)
+    for i in range(len(header)):
+        result.append([header[i]])
+    for row in reader:
+        for i in range(len(row)):
+            result[i].append(row[i])
+    series = {}
+    for i in range(len(result)):
+        series[result[i][0]] = result[i][1:]
+    return series
+
+NAME_RE = re.compile(' +')
+
+def e_name(n):
+    return NAME_RE.sub('_', n)
+
+def read_data(data):
+    ins = data.lower().splitlines()
+    ins[0] = e_name(ins[0].strip())
+    if ',' in ins[0]:
+        delimiter = ','
+    else:
+        delimiter = '\t'
+    return load_csv(ins, delimiter)
+
+def compare(reference, simulated, display_limit=-1):
+    '''
+    Compare 2 
+    '''
+    time = reference['time']
+    steps = len(time)
+    err = False
+    displayed = 0
+    for i in range(steps):
+        for n, series in list(reference.items()):
+            if n not in simulated:
+                if n in IGNORABLE_COLS:
+                    continue
+                log(ERROR, 'missing column %s in second file', n)
+                break
+            if len(reference[n]) != len(simulated[n]):
+                if display_limit >= 0 and displayed < display_limit:
+                    log(ERROR, 'len mismatch for %s (%d vs %d)',
+                        n, len(reference[n]), len(simulated[n]))
+                    displayed += 1
+                err = True
+                break
+            ref = float(series[i])
+            sim = float(simulated[n][i])
+            around_zero = isclose(ref, 0, abs_tol=1e-06) and isclose(sim, 0, abs_tol=1e-06)
+            if not around_zero and not isclose(ref, sim, rel_tol=1e-4):
+                if display_limit >= 0 and displayed < display_limit:
+                    log(ERROR, 'time %s mismatch in %s (%s != %s)', time[i], n, ref, sim)
+                    displayed += 1
+                err = True
+    return err
+
+def run_cmd(cmd):
+    '''
+    Runs a shell command, waits for it to complete, and returns stdout.
+    '''
+    call = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE,
+                            stderr=subprocess.PIPE)
+    out, err = call.communicate()
+    return (call.returncode, out, err)
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-e', '--ext', default='xmile',
+                        help='file extension of model to test, such as xmile or mdl')
+    parser.add_argument('-l', '--limit', default=10, type=int,
+                        help='number of lines of comparison errors to display per model, negative to disable')
+    parser.add_argument('CMD', help='command to run that will output model results to stdout')
+    parser.add_argument('DIR', help='path to test-models directory')
+    args = parser.parse_args()
+
+    model_suffix = '.' + args.ext
+
+    err = False
+
+    # test-models has directories that are 2-levels deep
+    for outer in os.listdir(args.DIR):
+        outer_path = os.path.join(args.DIR, outer)
+        if outer_path.startswith('.') or not os.path.isdir(outer_path):
+            continue
+
+        for inner in os.listdir(outer_path):
+            model_dir = os.path.join(outer_path, inner)
+            if not os.path.isdir(model_dir):
+                continue
+
+            for f in os.listdir(model_dir):
+                model_path = os.path.join(model_dir, f)
+                if not model_path.endswith(model_suffix):
+                    continue
+
+                log(DEBUG, '  RTEST %s/%s/%s', outer, inner, f)
+                err, mdata, err_out = run_cmd('%s %s' % (args.CMD, model_path))
+                if err:
+                    log(ERROR, '%s failed: %s', args.CMD, err_out)
+                    continue
+                sim = read_data(mdata.decode('utf-8'))
+                output_path = os.path.join(model_dir, OUTPUT_FILE)
+                ref = read_data(slurp(output_path))
+                err |= compare(ref, sim, display_limit=args.limit)
+
+    return err
+
+if __name__ == '__main__':
+    exit(main())

--- a/regression-test.py
+++ b/regression-test.py
@@ -147,7 +147,9 @@ def compare(reference, simulated, display_limit=-1):
             if n not in simulated:
                 if n in IGNORABLE_COLS:
                     continue
-                log(ERROR, 'missing column %s in second file', n)
+                if display_limit >= 0 and displayed < display_limit:
+                    log(ERROR, 'missing column %s in second file', n)
+                    displayed += 1
                 break
             if len(reference[n]) != len(simulated[n]):
                 if display_limit >= 0 and displayed < display_limit:
@@ -192,7 +194,7 @@ def main():
     # test-models has directories that are 2-levels deep
     for outer in os.listdir(args.DIR):
         outer_path = os.path.join(args.DIR, outer)
-        if outer_path.startswith('.') or not os.path.isdir(outer_path):
+        if outer.startswith('.') or not os.path.isdir(outer_path):
             continue
 
         for inner in os.listdir(outer_path):


### PR DESCRIPTION
These are two scripts I've been using to compare and validate model
output of the CSV files and models in this repository.  They should
run correctly under both python2 and python3.

I'm open to suggestions.  One sort of gnarly thing is that they're
~90% identical.  The common code could probably be refactored into a
module, but they were designed to only import the standard library.
Maybe I could refactor them into a single script if thats preferrable?

Also, if people don't think this is useful to have in this shared
repo, I'm happy to keep it with my projects, but it seems pretty
general and useful.


/cc @JamesPHoughton