### PR TITLE
Fix test_lookups.xmile model

### DIFF
--- a/samples/SIR/SIR.py
+++ b/samples/SIR/SIR.py
@@ -1,14 +1,14 @@
 """
-Python model test-models/samples/SIR/SIR.py
-Translated using PySD version 0.7.10
+Python model "SIR.py"
+Translated using PySD version 0.8.3
 """
 from __future__ import division
 import numpy as np
 from pysd import utils
 import xarray as xr
 
-from pysd.functions import cache
-from pysd import functions
+from pysd.py_backend.functions import cache
+from pysd.py_backend import functions
 
 _subscript_dict = {}
 
@@ -26,7 +26,10 @@ _namespace = {
     'FINAL TIME': 'final_time',
     'INITIAL TIME': 'initial_time',
     'SAVEPER': 'saveper',
-    'TIME STEP': 'time_step'}
+    'TIME STEP': 'time_step'
+}
+
+__pysd_version__ = "0.8.3"
 
 
 @cache('run')
@@ -35,6 +38,8 @@ def contact_infectivity():
     Contact Infectivity
 
     Persons/Persons/Day
+
+    constant
 
     A joint parameter listing both how many people you contact, and how likely 
         you are to give them the disease.
@@ -49,6 +54,8 @@ def duration():
 
     Days
 
+    constant
+
     How long are you infectious for?
     """
     return 5
@@ -60,6 +67,8 @@ def infectious():
     Infectious
 
     Persons
+
+    component
 
     The population with the disease, manifesting symptoms, and able to 
         transmit it to other people.
@@ -74,6 +83,8 @@ def recovered():
 
     Persons
 
+    component
+
     These people have recovered from the disease. Yay! Nobody dies in this 
         model.
     """
@@ -87,6 +98,8 @@ def recovering():
 
     Persons/Day
 
+    component
+
 
     """
     return infectious() / duration()
@@ -98,6 +111,8 @@ def succumbing():
     Succumbing
 
     Persons/Day
+
+    component
 
 
     """
@@ -111,6 +126,8 @@ def susceptible():
 
     Persons
 
+    component
+
     The population that has not yet been infected.
     """
     return integ_susceptible()
@@ -122,6 +139,8 @@ def total_population():
     Total Population
 
     Persons
+
+    constant
 
     This is just a simplification to make it easer to track how many folks 
         there are without having to sum up all the stocks.
@@ -136,6 +155,8 @@ def final_time():
 
     Day
 
+    constant
+
     The final time for the simulation.
     """
     return 100
@@ -147,6 +168,8 @@ def initial_time():
     INITIAL TIME
 
     Day
+
+    constant
 
     The initial time for the simulation.
     """
@@ -160,6 +183,8 @@ def saveper():
 
     Day [0,?]
 
+    component
+
     The frequency with which output is stored.
     """
     return time_step()
@@ -171,6 +196,8 @@ def time_step():
     TIME STEP
 
     Day [0,?]
+
+    constant
 
     The time step for the simulation.
     """

--- a/tests/lookups/README.md
+++ b/tests/lookups/README.md
@@ -28,6 +28,8 @@ Contributions
 | test_lookups_no-indirect.stmx  | Bobby Powers    | bobbypowers@gmail.com      | 8/28/15 | Stella 10.0.6           |
 | output_stella1006.csv          | Bobby Powers    | bobbypowers@gmail.com      | 8/28/15 | Stella 10.0.6           |
 | test_lookups_no-indirect.xmile | Bobby Powers    | bobbypowers@gmail.com      | 8/28/15 | xmileconv v0.1.0        |
+| test_lookups_xpts_sep.xmile    | Alexey Mulyukin | alexprey@yandex.ru         | 6/09/18 | Manual changes          |
+| test_lookups_ypts_sep.xmile    | Alexey Mulyukin | alexprey@yandex.ru         | 6/09/18 | Manual changes          |
 
 
 TODO

--- a/tests/lookups/test_lookups.xmile
+++ b/tests/lookups/test_lookups.xmile
@@ -32,14 +32,11 @@
                 <eqn>0</eqn>
                 <inflow>rate</inflow>
             </stock>
-            <aux name="lookup function table">
-                <eqn>0</eqn>
-                <gf>
-                    <yscale min="-1" max="1"/>
-                    <xpts>0,5,10,15,20,25,30,35,40,45</xpts>
-                    <ypts>0,0,1,1,0,0,-1,-1,0,0</ypts>
-                </gf>
-            </aux>
+            <gf name="lookup function table">
+                <yscale min="-1" max="1"/>
+                <xpts>0,5,10,15,20,25,30,35,40,45</xpts>
+                <ypts>0,0,1,1,0,0,-1,-1,0,0</ypts>
+            </gf>
             <aux name="lookup function call">
                 <eqn>lookup_function_table(Time)</eqn>
             </aux>

--- a/tests/lookups/test_lookups.xmile
+++ b/tests/lookups/test_lookups.xmile
@@ -41,7 +41,7 @@
                 </gf>
             </aux>
             <aux name="lookup function call">
-                <eqn>LOOKUP(lookup_function_table, Time)</eqn>
+                <eqn>lookup_function_table(Time)</eqn>
             </aux>
             <aux name="Lookup Linebreak Before Comma">
                 <doc>	This lookup has a line break before the comma.</doc>

--- a/tests/lookups/test_lookups_xpts_sep.xmile
+++ b/tests/lookups/test_lookups_xpts_sep.xmile
@@ -1,0 +1,96 @@
+<xmile xmlns="http://docs.oasis-open.org/xmile/ns/XMILE/v1.0" version="1.0">
+    <isee:prefs show_module_prefix="true" layer="model"/>
+    <header>
+        <options namespace="std"/>
+        <vendor>Ventana Systems, xmutil</vendor>
+        <product lang="en">Vensim, xmutil</product>
+    </header>
+    <sim_specs isee:simulation_delay="0" method="Euler" time_units="Months">
+        <start>0</start>
+        <stop>45</stop>
+        <dt>0.25</dt>
+    </sim_specs>
+    <dimensions/>
+    <model>
+        <variables>
+            <aux name="TIME STEP">
+                <doc>	The time step for the simulation.</doc>
+                <eqn>0.25</eqn>
+                <units>Minute</units>
+            </aux>
+            <aux name="INITIAL TIME">
+                <doc>	The initial time for the simulation.</doc>
+                <eqn>0</eqn>
+                <units>Minute</units>
+            </aux>
+            <aux name="FINAL TIME">
+                <doc>	The final time for the simulation.</doc>
+                <eqn>45</eqn>
+                <units>Minute</units>
+            </aux>
+            <stock name="accumulation">
+                <eqn>0</eqn>
+                <inflow>rate</inflow>
+            </stock>
+            <gf name="lookup function table">
+                <yscale min="-1" max="1"/>
+                <xpts sep=";">0;5;10;15;20;25;30;35;40;45</xpts>
+                <ypts>0,0,1,1,0,0,-1,-1,0,0</ypts>
+            </gf>
+            <aux name="lookup function call">
+                <eqn>lookup_function_table(Time)</eqn>
+            </aux>
+            <aux name="Lookup Linebreak Before Comma">
+                <doc>	This lookup has a line break before the comma.</doc>
+                <eqn>0</eqn>
+                <gf>
+                    <yscale min="0.1" max="1"/>
+                    <xpts>0,1.25,1.5,1.75,2,2.25,2.5,2.75,3,3.25,3.5,3.75,4</xpts>
+                    <ypts>1,1,0.98,0.9,0.75,0.45,0.25,0.17,0.14,0.12,0.11,0.1,0.1</ypts>
+                </gf>
+            </aux>
+            <flow name="rate">
+                <eqn>lookup_function_call</eqn>
+            </flow>
+            <aux name="SAVEPER">
+                <doc>	The frequency with which output is stored.</doc>
+                <eqn>TIME_STEP</eqn>
+                <units>Minute</units>
+            </aux>
+        </variables>
+        <views>
+            <view>
+                <aux name="lookup_function_table" x="413" y="100"/>
+                <aux name="lookup_function_call" x="480" y="164"/>
+                <connector uid="3" angle="-43.688112217495942">
+                    <from>lookup_function_table</from>
+                    <to>lookup_function_call</to>
+                </connector>
+                <stock name="accumulation" x="576" y="228"/>
+                <flow name="rate" x="480" y="229">
+                    <pts>
+                        <pt x="432" y="229"/>
+                        <pt x="576" y="228"/>
+                    </pts>
+                </flow>
+                <connector uid="10" angle="270">
+                    <from>lookup_function_call</from>
+                    <to>rate</to>
+                </connector>
+                <connector uid="12" angle="232.25319461272539">
+                    <from>Time</from>
+                    <to>lookup_function_call</to>
+                </connector>
+                <aux name="Lookup_Linebreak_Before_Comma" x="490" y="330"/>
+                <connector uid="34" angle="90">
+                    <from>TIME_STEP</from>
+                    <to>SAVEPER</to>
+                </connector>
+                <aux name="SAVEPER" x="100" y="158"/>
+                <aux name="FINAL_TIME" x="100" y="158"/>
+                <aux name="INITIAL_TIME" x="100" y="158"/>
+                <aux name="TIME_STEP" x="100" y="158"/>
+            </view>
+        </views>
+    </model>
+</xmile>

--- a/tests/lookups/test_lookups_xscale.xmile
+++ b/tests/lookups/test_lookups_xscale.xmile
@@ -1,0 +1,96 @@
+<xmile xmlns="http://docs.oasis-open.org/xmile/ns/XMILE/v1.0" version="1.0">
+    <isee:prefs show_module_prefix="true" layer="model"/>
+    <header>
+        <options namespace="std"/>
+        <vendor>Ventana Systems, xmutil</vendor>
+        <product lang="en">Vensim, xmutil</product>
+    </header>
+    <sim_specs isee:simulation_delay="0" method="Euler" time_units="Months">
+        <start>0</start>
+        <stop>45</stop>
+        <dt>0.25</dt>
+    </sim_specs>
+    <dimensions/>
+    <model>
+        <variables>
+            <aux name="TIME STEP">
+                <doc>	The time step for the simulation.</doc>
+                <eqn>0.25</eqn>
+                <units>Minute</units>
+            </aux>
+            <aux name="INITIAL TIME">
+                <doc>	The initial time for the simulation.</doc>
+                <eqn>0</eqn>
+                <units>Minute</units>
+            </aux>
+            <aux name="FINAL TIME">
+                <doc>	The final time for the simulation.</doc>
+                <eqn>45</eqn>
+                <units>Minute</units>
+            </aux>
+            <stock name="accumulation">
+                <eqn>0</eqn>
+                <inflow>rate</inflow>
+            </stock>
+            <gf name="lookup function table">
+                <yscale min="-1" max="1"/>
+                <xscale min="0" max="45" />
+                <ypts>0,0,1,1,0,0,-1,-1,0,0</ypts>
+            </gf>
+            <aux name="lookup function call">
+                <eqn>lookup_function_table(Time)</eqn>
+            </aux>
+            <aux name="Lookup Linebreak Before Comma">
+                <doc>	This lookup has a line break before the comma.</doc>
+                <eqn>0</eqn>
+                <gf>
+                    <yscale min="0.1" max="1"/>
+                    <xpts>0,1.25,1.5,1.75,2,2.25,2.5,2.75,3,3.25,3.5,3.75,4</xpts>
+                    <ypts>1,1,0.98,0.9,0.75,0.45,0.25,0.17,0.14,0.12,0.11,0.1,0.1</ypts>
+                </gf>
+            </aux>
+            <flow name="rate">
+                <eqn>lookup_function_call</eqn>
+            </flow>
+            <aux name="SAVEPER">
+                <doc>	The frequency with which output is stored.</doc>
+                <eqn>TIME_STEP</eqn>
+                <units>Minute</units>
+            </aux>
+        </variables>
+        <views>
+            <view>
+                <aux name="lookup_function_table" x="413" y="100"/>
+                <aux name="lookup_function_call" x="480" y="164"/>
+                <connector uid="3" angle="-43.688112217495942">
+                    <from>lookup_function_table</from>
+                    <to>lookup_function_call</to>
+                </connector>
+                <stock name="accumulation" x="576" y="228"/>
+                <flow name="rate" x="480" y="229">
+                    <pts>
+                        <pt x="432" y="229"/>
+                        <pt x="576" y="228"/>
+                    </pts>
+                </flow>
+                <connector uid="10" angle="270">
+                    <from>lookup_function_call</from>
+                    <to>rate</to>
+                </connector>
+                <connector uid="12" angle="232.25319461272539">
+                    <from>Time</from>
+                    <to>lookup_function_call</to>
+                </connector>
+                <aux name="Lookup_Linebreak_Before_Comma" x="490" y="330"/>
+                <connector uid="34" angle="90">
+                    <from>TIME_STEP</from>
+                    <to>SAVEPER</to>
+                </connector>
+                <aux name="SAVEPER" x="100" y="158"/>
+                <aux name="FINAL_TIME" x="100" y="158"/>
+                <aux name="INITIAL_TIME" x="100" y="158"/>
+                <aux name="TIME_STEP" x="100" y="158"/>
+            </view>
+        </views>
+    </model>
+</xmile>

--- a/tests/lookups/test_lookups_ypts_sep.xmile
+++ b/tests/lookups/test_lookups_ypts_sep.xmile
@@ -1,0 +1,96 @@
+<xmile xmlns="http://docs.oasis-open.org/xmile/ns/XMILE/v1.0" version="1.0">
+    <isee:prefs show_module_prefix="true" layer="model"/>
+    <header>
+        <options namespace="std"/>
+        <vendor>Ventana Systems, xmutil</vendor>
+        <product lang="en">Vensim, xmutil</product>
+    </header>
+    <sim_specs isee:simulation_delay="0" method="Euler" time_units="Months">
+        <start>0</start>
+        <stop>45</stop>
+        <dt>0.25</dt>
+    </sim_specs>
+    <dimensions/>
+    <model>
+        <variables>
+            <aux name="TIME STEP">
+                <doc>	The time step for the simulation.</doc>
+                <eqn>0.25</eqn>
+                <units>Minute</units>
+            </aux>
+            <aux name="INITIAL TIME">
+                <doc>	The initial time for the simulation.</doc>
+                <eqn>0</eqn>
+                <units>Minute</units>
+            </aux>
+            <aux name="FINAL TIME">
+                <doc>	The final time for the simulation.</doc>
+                <eqn>45</eqn>
+                <units>Minute</units>
+            </aux>
+            <stock name="accumulation">
+                <eqn>0</eqn>
+                <inflow>rate</inflow>
+            </stock>
+            <gf name="lookup function table">
+                <yscale min="-1" max="1"/>
+                <xpts>0,5,10,15,20,25,30,35,40,45</xpts>
+                <ypts sep=";">0;0;1;1;0;0;-1;-1;0;0</ypts>
+            </gf>
+            <aux name="lookup function call">
+                <eqn>lookup_function_table(Time)</eqn>
+            </aux>
+            <aux name="Lookup Linebreak Before Comma">
+                <doc>	This lookup has a line break before the comma.</doc>
+                <eqn>0</eqn>
+                <gf>
+                    <yscale min="0.1" max="1"/>
+                    <xpts>0,1.25,1.5,1.75,2,2.25,2.5,2.75,3,3.25,3.5,3.75,4</xpts>
+                    <ypts>1,1,0.98,0.9,0.75,0.45,0.25,0.17,0.14,0.12,0.11,0.1,0.1</ypts>
+                </gf>
+            </aux>
+            <flow name="rate">
+                <eqn>lookup_function_call</eqn>
+            </flow>
+            <aux name="SAVEPER">
+                <doc>	The frequency with which output is stored.</doc>
+                <eqn>TIME_STEP</eqn>
+                <units>Minute</units>
+            </aux>
+        </variables>
+        <views>
+            <view>
+                <aux name="lookup_function_table" x="413" y="100"/>
+                <aux name="lookup_function_call" x="480" y="164"/>
+                <connector uid="3" angle="-43.688112217495942">
+                    <from>lookup_function_table</from>
+                    <to>lookup_function_call</to>
+                </connector>
+                <stock name="accumulation" x="576" y="228"/>
+                <flow name="rate" x="480" y="229">
+                    <pts>
+                        <pt x="432" y="229"/>
+                        <pt x="576" y="228"/>
+                    </pts>
+                </flow>
+                <connector uid="10" angle="270">
+                    <from>lookup_function_call</from>
+                    <to>rate</to>
+                </connector>
+                <connector uid="12" angle="232.25319461272539">
+                    <from>Time</from>
+                    <to>lookup_function_call</to>
+                </connector>
+                <aux name="Lookup_Linebreak_Before_Comma" x="490" y="330"/>
+                <connector uid="34" angle="90">
+                    <from>TIME_STEP</from>
+                    <to>SAVEPER</to>
+                </connector>
+                <aux name="SAVEPER" x="100" y="158"/>
+                <aux name="FINAL_TIME" x="100" y="158"/>
+                <aux name="INITIAL_TIME" x="100" y="158"/>
+                <aux name="TIME_STEP" x="100" y="158"/>
+            </view>
+        </views>
+    </model>
+</xmile>


### PR DESCRIPTION
# Added
- Add the new xmile models to test various kind of settings for lookups:
   - Custom values separator by `sep=""` attribute in `<xpts>` and `<ypts>` nodes of lookup
   - Using `<xscale min="" max="" />` node for defining x-points instead using `<xpts>` with list

# Changed
- Fix `test_lookups.xmile` model definition
  - Extract lookup node `<gf>` from `<aux>` to make this lookup not inline and test global lookup definition
  - Fix usage of lookup table, use direct name of lookup as a function `lookup_name(x)`, instead using a special function `LOOKUP(lookup_name, x)`