### PR TITLE
Add a simple test for PySD documentation

### DIFF
--- a/tests/multiple_lines_def/README.md
+++ b/tests/multiple_lines_def/README.md
@@ -1,0 +1,13 @@
+Test multiple lines def
+============================
+
+Simple model where a variable is declared in 6 lines to check if the documentation is well constructed.
+
+
+Contributions
+-------------
+
+| Component                     | Author          | Contact                         | Date     | Software Version                                     |
+|:----------------------------- |:--------------- |:------------------------------- |:-------- |:---------------------------------------------------- |
+| `test_multiple_lines_def.mdl` | Eneko Martin    | eneko.martin.martinez@gmail.com | 12/15/20 | Vensim DSS for Windows 7.3.4 single precision (x32)  |
+| `output.tab `                 | Eneko Martin    | eneko.martin.martinez@gmail.com | 12/15/20 | Vensim DSS for Windows 7.3.4 single precision (x32)  |

--- a/tests/multiple_lines_def/output.tab
+++ b/tests/multiple_lines_def/output.tab
@@ -1,0 +1,3 @@
+Time	FINAL TIME	INITIAL TIME	price[banana]	price[apple]	price[orange]	price[cherry]	price[pear]	price[tomato]	SAVEPER	TIME STEP
+0	1	0	1.2	2.3	3.2	2.3	0.9	1.4	1	1
+1									1	

--- a/tests/multiple_lines_def/test_multiple_lines_def.mdl
+++ b/tests/multiple_lines_def/test_multiple_lines_def.mdl
@@ -1,0 +1,99 @@
+{UTF-8}
+fruits:
+	banana, apple, orange, cherry, pear, tomato
+	~	
+	~		|
+
+price[banana]=
+	1.2 ~~|
+price[apple]=
+	2.3 ~~|
+price[orange]=
+	3.2 ~~|
+price[cherry]=
+	2.3 ~~|
+price[pear]=
+	0.9 ~~|
+price[tomato]=
+	1.4
+	~	euros/kg [0,100]
+	~	Price of the fruits
+	|
+
+********************************************************
+	.Control
+********************************************************~
+		Simulation Control Parameters
+	|
+
+FINAL TIME  = 1
+	~	Month
+	~	The final time for the simulation.
+	|
+
+INITIAL TIME  = 0
+	~	Month
+	~	The initial time for the simulation.
+	|
+
+SAVEPER  = 
+        TIME STEP 
+	~	Month [0,?]
+	~	The frequency with which output is stored.
+	|
+
+TIME STEP  = 1
+	~	Month [0,?]
+	~	The time step for the simulation.
+	|
+
+\\\---/// Sketch information - do not modify anything except names
+V300  Do not put anything below this section - it will be ignored
+*View 1
+$192-192-192,0,Times New Roman|12||0-0-0|0-0-0|0-0-255|-1--1--1|-1--1--1|96,96,100,0
+10,1,price,131,124,17,11,8,3,0,0,0,0,0,0
+///---\\\
+:L<%^E!@
+1:Current.vdf
+1:Z:\CREAF\dev\pysd\tests\test-models\tests\subscripted_delays\Current.vdf
+9:Current
+15:0,0,0,0,0,0
+19:100,0
+27:0,
+34:0,
+4:Time
+5:price[fruits]
+35:Date
+36:YYYY-MM-DD
+37:2000
+38:1
+39:1
+40:2
+41:0
+42:1
+24:0
+25:1
+26:1
+57:1
+54:0
+55:0
+59:0
+56:0
+58:0
+44:65001
+46:0
+45:1
+49:1
+50:0
+51:
+52:
+53:
+43:output
+47:Current
+48:
+6:apple
+6:banana
+6:cherry
+6:orange
+6:pear
+6:tomato


### PR DESCRIPTION
Add a simple test for PySD documentation where an element is defined in more than 5 lines. New documentation in PySD will write have several equations if the element is defined in several lines, this needs to be tested somehow.